### PR TITLE
updating class hierarchy to match typescript standards

### DIFF
--- a/definition-generator/src/generate.ts
+++ b/definition-generator/src/generate.ts
@@ -53,7 +53,7 @@ function find<T>(values: T[], predicate: (T) => boolean): T {
         if (predicate(values[i]))
             return values[i];
     }
-    
+
     return null;
 }
 
@@ -333,7 +333,7 @@ function with_underscore(type: string) {
     var prefix = /[\w\.]+/.exec(type)[0];
     var suffix = type.substring(prefix.length);
 
-    return prefix + '.__Class' + suffix;
+    return prefix + '__Class' + suffix;
 }
 
 function generate_class_extends(docs: doctrine.JSDoc) {
@@ -439,11 +439,8 @@ function get_type_name(tag) {
 
 function generate_class(name: string, prototype: combine.Symbol) {
     var constructor = prototype[''];
-    var acc = 'class ' + name + generics(constructor.jsdoc) + ' extends ' + name + '.__Class' + generics(constructor.jsdoc) + ' { }\n';
-
-    acc += 'module ' + name + ' {\n';
-    acc += '    ' + '/** Fake class which should be extended to avoid inheriting static properties */\n';
-    acc += '    ' + 'class __Class' + generics(constructor.jsdoc) + ' ' + generate_class_extends(constructor.jsdoc) + generate_implements(constructor.jsdoc) + '{\n';
+    var acc = '/** Fake class which should be extended to avoid inheriting static properties */\n';
+    acc += 'class ' + name + generics(constructor.jsdoc) + '__Class' + generics(constructor.jsdoc) + ' ' + generate_class_extends(constructor.jsdoc) + generate_implements(constructor.jsdoc) + ' { \n';
 
     var text = constructor.originalText.replace(/\n/g, '\n' + '    ' + '    ');
 
@@ -485,8 +482,9 @@ function generate_class(name: string, prototype: combine.Symbol) {
 
     add_members(prototype);
 
-    acc += '    ' + '}\n';
-    acc += '}';
+    acc += '} \n';
+    acc += 'class ' + name + generics(constructor.jsdoc) + ' extends ' + name + '__Class' + generics(constructor.jsdoc) + ' { }\n';
+    acc += 'module ' + name + ' { }\n';
 
     return acc;
 }
@@ -604,8 +602,8 @@ export function defs(symbols: combine.Symbols): Generated {
 
         if (!modules[moduleName])
             modules[moduleName] = {};
-        
-        if (constructor.jsdoc.tags.some(t => t.title === 'interface')) 
+
+        if (constructor.jsdoc.tags.some(t => t.title === 'interface'))
             modules[moduleName][propertyName] = generate_interface(propertyName, symbol);
         else
             modules[moduleName][propertyName] = generate_class(propertyName, symbol);

--- a/definition-generator/test/generate_spec.ts
+++ b/definition-generator/test/generate_spec.ts
@@ -33,7 +33,7 @@ describe('generate', () => {
     it('class', () => {
         expect(parse('test/class.js')).toEqual({
             "example": {
-                "Class": "class Class extends Class.__Class { } module Class { class __Class implements example.Interface { constructor(x: number); constructor(x: string); thisAssignment: string; thisDeclaration: number; overloadedMethod(x: number): void; overloadedMethod(x: string): void; interfaceMethod(x: number): void; interfaceMethod(x: string): void; } }"
+                "Class": "class Class__Class implements example.Interface { constructor(x: number); constructor(x: string); thisAssignment: string; thisDeclaration: number; overloadedMethod(x: number): void; overloadedMethod(x: string): void; interfaceMethod(x: number): void; interfaceMethod(x: string): void; } class Class extends Class__Class { } module Class { }"
             }
         });
     });
@@ -73,7 +73,7 @@ describe('generate', () => {
     it('subclass', () => {
         expect(parse('test/subclass.js')).toEqual({
             "example": {
-                "SubClass": "class SubClass extends SubClass.__Class { } module SubClass { class __Class extends example.Class.__Class { constructor(); } }"
+                "SubClass": "class SubClass__Class extends example.Class__Class { constructor(); } class SubClass extends SubClass__Class { } module SubClass { }"
             }
         });
     });
@@ -132,7 +132,7 @@ describe('generate', () => {
         it('local class', () => {
             expect(parse('test/requirejs_local_class.js')).toEqual({
                 MODULE : {
-                    LocalClass : 'class LocalClass extends LocalClass.__Class { } module LocalClass { class __Class { constructor(x: number); memberFunction(x: number): void; } }'
+                    LocalClass : 'class LocalClass__Class { constructor(x: number); memberFunction(x: number): void; } class LocalClass extends LocalClass__Class { } module LocalClass { }'
                 }
             });
         });


### PR DESCRIPTION
Addresses: Illegal referencing own base expression #7 

I've used the second suggested way (in the issue comments) to resolve the issue.
