### PR TITLE
add include_private flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ closure2ts
   [--globals output/dir/global-declarations.d.ts]
   [--input_root input/dir]
   [--output_root output/dir]
+  [--include_private boolean]
   input/dir/input-file.js output/dir/output-file.d.ts
   input/dir/another-input-file.js output/dir/another-output-file.d.ts
   ...
@@ -37,6 +38,7 @@ If this option isn't present, we will simply look for global symbols in the inpu
 * `--globals output/dir/global-declarations.d.ts` A TypeScript declaration that will be referenced at the top of every output file.
 * `--input_root input/dir` Root of inputs, considered when computing relative paths for `///<reference path="..." />` tags.
 * `--output_root output/dir` Root of outputs, considered when computing relative paths for `///<reference path="..." />` tags.
+* `--include_private boolean` Whether to include items marked as private (@private), defaults to false.
 
 # Structure
 

--- a/definition-generator/src/options.ts
+++ b/definition-generator/src/options.ts
@@ -23,6 +23,7 @@ export var provides = get_option('provides');
 export var globals = get_option('globals');
 export var inputRoot = get_option('input_root') || '';
 export var outputRoot = get_option('output_root') || '';
+export var includePrivate = get_option('include_private') || false;
 export var todo: InputOutput[] = [];
 
 for (var i = 0; i < options.length; i += 2) {

--- a/definition-generator/src/parser.ts
+++ b/definition-generator/src/parser.ts
@@ -6,6 +6,7 @@
 import esprima = require('esprima');
 import escodegen = require('escodegen');
 import doctrine = require('doctrine');
+import options = require('./options');
 
 function values(object: Object) {
     return Object.keys(object).map(k => object[k]);
@@ -478,5 +479,5 @@ export function jsdoc(code: string): File {
     var comments = extract_jsdoc(tree.body);
     var parsed = parse_comments(comments);
 
-    return remove_private(parsed);
+    return options.includePrivate ? parsed : remove_private(parsed);
 }


### PR DESCRIPTION
The tool previously ignored all items annotated as private. Although this is often desired, I have a case where I need to call into something marked private. Since it is still accessible via JS, this is possible. Adding this flag allows you to keep type safety.

flag: --include_private
defaults: false
use: --include_private true