### PR TITLE
Fix issues when performing "npm install -g".

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ git clone git@github.com:fivetran/typescript-closure-tools.git
 cd typescript-closure-tools
 git submodule update --init
 npm install
-tsc --module commonjs definition-generator/src/*.ts
 node definition-generator/src/main.js test/example.js test/example.d.ts # Run a single example
 sudo npm install -g 
 ```

--- a/definition-generator/src/cli.js
+++ b/definition-generator/src/cli.js
@@ -1,2 +1,3 @@
 #!/usr/bin/env node
-require('./main.js');
+var path = require('path');
+require(path.resolve(__dirname, 'main.js'));

--- a/externs-generator/src/cli.js
+++ b/externs-generator/src/cli.js
@@ -1,2 +1,3 @@
 #!/usr/bin/env node
-require('./main.js');
+var path = require('path');
+require(path.resolve(__dirname, 'main.js'));

--- a/main.min.js
+++ b/main.min.js
@@ -640,8 +640,6 @@ var pretty_print = require('./pretty_print');
 var options = require('./options');
 var mkdirp = require('mkdirp');
 require('colors');
-exports.currentInput;
-exports.currentOutput;
 options.todo.forEach(function (todo) {
     exports.currentInput = todo.input;
     exports.currentOutput = todo.output;
@@ -11140,10 +11138,11 @@ module.exports={
   },
   "dist": {
     "shasum": "4e299d8cc33087b7f29c19e2b9e84362abe35453",
-    "tarball": "http://registry.npmjs.org/escodegen/-/escodegen-1.7.0.tgz"
+    "tarball": "http://nexus.iplabs.de/content/groups/npm/escodegen/-/escodegen-1.7.0.tgz"
   },
   "directories": {},
-  "_resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.0.tgz"
+  "_resolved": "http://nexus.iplabs.de/content/groups/npm/escodegen/-/escodegen-1.7.0.tgz",
+  "readme": "ERROR: No README data found!"
 }
 
 },{}],44:[function(require,module,exports){

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
     "version": "0.0.4",
     "description": "Command-line tools to convert closure-style JSDoc annotations to typescript, and to convert typescript sources to closure externs files",
     "author": "George Fraser",
+    "contributors": [
+      "Benjamin P. Jung <headcr4sh@gmail.com>"
+    ],
     "keywords": [
         "TypeScript",
         "Closure"
@@ -23,6 +26,9 @@
     "devDependencies": {
         "jasmine-node": "*",
         "browserify": "*"
+    },
+    "scripts": {
+      "prepublish": "tsc --module commonjs definition-generator/src/*.ts && tsc --module commonjs externs-generator/src/*.ts"
     },
     "bin": {
         "ts2externs": "./externs-generator/src/cli.js",


### PR DESCRIPTION
* Resolve the "main.js" file correctly using "path.resolve"
  in conjunction with the "__dirname" variable.
* Add a prepublish script to make sure that the TypeScript
  compiler is being invoked before the package will be
  installed. This reduces the need for the manual invocation
  of "tsc" as described in the README.