### PR TITLE
Add support for Node v10

### DIFF
--- a/definition-generator/src/main.ts
+++ b/definition-generator/src/main.ts
@@ -29,7 +29,7 @@ options.todo.forEach(todo => {
         if (fs.existsSync(todo.output) && fs.readFileSync(todo.output, 'utf8') === pretty) {
             console.error('No changes\t'.green + todo.output);
         } else {
-            fs.writeFile(todo.output, pretty);
+            fs.writeFileSync(todo.output, pretty);
             console.error('Wrote\t'.red + todo.output);
         }
     } catch (e) {


### PR DESCRIPTION
Running this via Node v10 will fail with the following error:
`TypeError [ERR_INVALID_CALLBACK]: Callback must be a function`

This is because `fs.writeFile` now throws an error if a callback isn't provided, it is no longer optional. In Node v8 it was marked as deprecated so running this tool is v8 worked, but it would print out deprecation warnings.

I've changed the call to `fs.writeFileSync` which doesn't need a callback which works in v10. Since the rest of the function in question was already using the synchronous versions of `fs` functions, it seemed fine to do so with `writeFile` as well.

This fixes https://github.com/trodi/blockly-d.ts/issues/8